### PR TITLE
fix mkdir

### DIFF
--- a/openxai/LoadModel.py
+++ b/openxai/LoadModel.py
@@ -40,7 +40,7 @@ def LoadModel(data_name: str, ml_model, pretrained: bool = True):
         inputs, labels = data_iter.next()
     
     if pretrained:
-        os.mkdir('./pretrained')
+        os.makedirs('./pretrained', exist_ok=True)
         if data_name == 'synthetic':
             if ml_model == 'ann':
                 r = requests.get('https://dataverse.harvard.edu/api/access/datafile/6718575', allow_redirects=True)


### PR DESCRIPTION
## Description
Changed `os.mkdir(...)` to `os.makedirs(..., exist_ok=True)` to fix the bug when pretrained folder already exists.

Together with commit da70155402c3a3ef60a6c0293f8246e8772e40b3 by @chirag126, this should fix #4.

## Test
Tested locally by running `python openxai/api.py`.

Also tested locally by running the following piece of code outside the OpenXAI folder:

```python
from openxai.api import OpenXAI
oxai = OpenXAI(data_name="german", model_name="ann", explainer_name="lime")
df_full = oxai.query()
print(df_full.head())
```

and obtained the following outputs:

```
   duration    amount  installment-rate  ...  label  prediction  is_test
0  0.205882  0.228094          0.666667  ...    0.0         1.0      0.0
1  0.294118  0.072564          1.000000  ...    1.0         1.0      0.0
2  0.294118  0.064395          1.000000  ...    1.0         1.0      0.0
3  0.470588  0.355607          1.000000  ...    1.0         1.0      0.0
4  0.470588  0.421916          1.000000  ...    1.0         1.0      0.0

[5 rows x 123 columns]
```