### PR TITLE
add option for no scaler

### DIFF
--- a/openxai/api.py
+++ b/openxai/api.py
@@ -18,7 +18,7 @@ class OpenXAI(object):
         self.explainer_name = explainer_name
 
         self.loader_train, self.loader_test = return_loaders(
-            data_name=data_name, download=True)
+            data_name=data_name, download=True, scaler="none")
         self.model = LoadModel(data_name=data_name, ml_model=model_name)
 
         dataset_tensor = torch.FloatTensor(self.loader_train.dataset.data)
@@ -109,7 +109,8 @@ if __name__ == '__main__':
     data_names = ["compas", "adult", "german"]
     explainer_names = ["grad", "sg", "itg", "ig", "shap", "lime"]
     for data_name in data_names:
-        _, loader_test = return_loaders(data_name=data_name, download=True)
+        _, loader_test = return_loaders(
+            data_name=data_name, download=True, scaler="none")
         X, y = iter(loader_test).next()
         X = X.to(dtype=torch.float32)
         X = X[:4]  # use smaller batch

--- a/openxai/dataloader.py
+++ b/openxai/dataloader.py
@@ -21,7 +21,7 @@ class TabularDataLoader(data.Dataset):
         Load training dataset
         :param path: string with path to training set
         :param label: string, column name for label
-        :param scale: string; either 'minmax' or 'standard'
+        :param scale: string; 'minmax', 'standard', or 'none'
         :param dict: standard params of gaussian dgp
         :return: tensor with training data
         """
@@ -124,12 +124,16 @@ class TabularDataLoader(data.Dataset):
             self.scaler = MinMaxScaler()
         elif scale == 'standard':
             self.scaler = StandardScaler()
+        elif scale == 'none':
+            self.scaler = None
         else:
-            raise NotImplementedError('The current version of DataLoader class only provides the following transformations: {minmax, standard}')
-            
-        self.scaler.fit_transform(self.X)
+            raise NotImplementedError('The current version of DataLoader class only provides the following transformations: {minmax, standard, none}')
         
-        self.data = self.scaler.transform(self.X)
+        if self.scaler is not None:
+            self.scaler.fit_transform(self.X)
+            self.data = self.scaler.transform(self.X)
+        else:
+            self.data = self.X.values
         self.targets = self.dataset[self.target]
 
     def __len__(self):


### PR DESCRIPTION
## Description

Add an option for not using any scaler when preprocessing the data and change the api to return the none-scaled data. This is desirable when we want to display the original features to users.

## Test

Tested by successfully running `python openxai/api.py`.