### PR TITLE
Add rcdv and lending-club

### DIFF
--- a/openxai/LoadModel.py
+++ b/openxai/LoadModel.py
@@ -125,6 +125,38 @@ def LoadModel(data_name: str, ml_model, pretrained: bool = True):
                 open(model_path, 'wb').write(r.content)
                 model = LogisticRegression(input_dim=inputs.shape[1])
                 model.load_state_dict(torch.load(model_path, map_location=torch.device('cpu')))
+        elif data_name == 'rcdv':
+            if ml_model == 'ann':
+                r = requests.get('https://dataverse.harvard.edu/api/access/datafile/6990767', allow_redirects=True)
+                model_path = './pretrained/ann_rcdv.pt'
+                open(model_path, 'wb').write(r.content)
+                model = model_ann.ANN_softmax(input_layer=inputs.shape[1],
+                                              hidden_layer_1=100,
+                                              num_of_classes=2)
+                model.load_state_dict(torch.load(model_path, map_location=torch.device('cpu')))
+            
+            elif ml_model == 'lr':
+                r = requests.get('https://dataverse.harvard.edu/api/access/datafile/6990768', allow_redirects=True)
+                model_path = './pretrained/lr_rcdv.pt'
+                open(model_path, 'wb').write(r.content)
+                model = LogisticRegression(input_dim=inputs.shape[1])
+                model.load_state_dict(torch.load(model_path, map_location=torch.device('cpu')))
+        elif data_name == 'lending-club':
+            if ml_model == 'ann':
+                r = requests.get('https://dataverse.harvard.edu/api/access/datafile/6990764', allow_redirects=True)
+                model_path = './pretrained/ann_lending-club.pt'
+                open(model_path, 'wb').write(r.content)
+                model = model_ann.ANN_softmax(input_layer=inputs.shape[1],
+                                              hidden_layer_1=100,
+                                              num_of_classes=2)
+                model.load_state_dict(torch.load(model_path, map_location=torch.device('cpu')))
+            
+            elif ml_model == 'lr':
+                r = requests.get('https://dataverse.harvard.edu/api/access/datafile/6990766', allow_redirects=True)
+                model_path = './pretrained/lr_lending-club.pt'
+                open(model_path, 'wb').write(r.content)
+                model = LogisticRegression(input_dim=inputs.shape[1])
+                model.load_state_dict(torch.load(model_path, map_location=torch.device('cpu')))
         else:
             raise NotImplementedError(
                  'The current version of >LoadModel< does not support this data set.')


### PR DESCRIPTION
## Description

Refactor dataloader.py and LoadModel.py to accommodate the new datasets and models prepared by Caiwei. 


## Test

Running the following code will yield an accuracy with 1.0. Changing to `data_name='lending-club'` will yield an accuracy with 0.815.

```python
data_name = 'rcdv'
import torch
from openxai.dataloader import return_loaders
loader_train, loader_test = return_loaders(data_name=data_name, download=True)
inputs, labels = iter(loader_test).next()

from openxai import LoadModel
model = LoadModel(data_name=data_name, ml_model='ann', pretrained=True)

prob = model(inputs.to(dtype=torch.float))
pred = torch.argmax(prob, dim=1)
accuracy = sum(pred == labels) / len(pred)
```