### PR TITLE
Fix deprecated np.float type hint

### DIFF
--- a/openxai/evaluator.py
+++ b/openxai/evaluator.py
@@ -376,7 +376,7 @@ class Evaluator():
 
         return np.mean(np.abs(y - y_perturbed), axis=0)[0]
 
-    def _compute_Lp_norm_diff(self, vec1, vec2, normalize_to_relative_change: bool = True, eps: np.float = 0.001):
+    def _compute_Lp_norm_diff(self, vec1, vec2, normalize_to_relative_change: bool = True, eps: float = 0.001):
         """ Returns the Lp norm of the difference between vec1 and vec2.
         Args:
             normalize_by_vec1: when true, normalizes the difference between vec1 and vec2 by vec1


### PR DESCRIPTION
`np.float` is an alias for the builtin `float` type and was [deprecated starting at numpy version 1.20](https://numpy.org/doc/stable/release/1.20.0-notes.html).