### PR TITLE
Fix calculation for log standard error

### DIFF
--- a/evaluate_metrics.py
+++ b/evaluate_metrics.py
@@ -106,7 +106,8 @@ if __name__ == '__main__':
                     std_err = np.std(score) / np.sqrt(len(score))
                     print(f"{metric}: {mean_score:.3f} \u00B1 {std_err:.3f}")
                     if metric in stability_metrics:
-                        log_mu, log_std = np.log(mean_score), np.log(std_err)
+                        log_mu = np.log(mean_score)
+                        log_std = np.std(np.log(score)) / np.sqrt(len(score))
                         print(f"log({metric}): {log_mu:.3f} \u00B1 {log_std:.3f}")
 
                     # Save results

--- a/openxai/explainers/catalog/iee/__init__.py
+++ b/openxai/explainers/catalog/iee/__init__.py
@@ -1,0 +1,1 @@
+from .iee import IEE

--- a/openxai/explainers/catalog/iee/iee.py
+++ b/openxai/explainers/catalog/iee/iee.py
@@ -1,0 +1,16 @@
+import torch
+from iee import Explainer
+from ...api import BaseExplainer
+
+
+class IEE(BaseExplainer):
+    def __init__(self, model, X=None, mode="classifier", grid_resolution=None):
+        super().__init__(model)
+        self._explainer = Explainer(model, X, mode, grid_resolution)
+
+    def get_explanations(self, x: torch.FloatTensor, label=None) -> torch.FloatTensor:
+        self.model.eval()
+        iee_values = torch.FloatTensor(self._explainer(x))
+        if iee_values.size()[-1] == 2:
+            iee_values = iee_values[:, :, 1]
+        return iee_values


### PR DESCRIPTION
I created this PR to fix the code for calculating log standard error.

**Before**
```py
log_mu, log_std = np.log(mean_score), np.log(std_err)
```

**After**
```py
log_mu = np.log(mean_score)
log_std = np.std(np.log(score)) / np.sqrt(len(score))
```